### PR TITLE
Add ProxyFactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,58 +3,63 @@
 ## Goals
 
 1. Optimize deploy gas usage for the per-user contracts.
-2. Optimize run-time gas usage for the ETH deposit to deposit address path. 
-This should be kept below 42000 gas. (Since naive approaches would have 2 value 
-tx being sent, one from the customer, one forwarding to cold manually, 
+2. Optimize run-time gas usage for the ETH deposit to deposit address path.
+This should be kept below 42000 gas. (Since naive approaches would have 2 value
+tx being sent, one from the customer, one forwarding to cold manually,
 21000 x 2 = 42000... so we should be better than this)
 3. Allow killing the contract. This will cause all ETH deposits to fail.
-4. Support ERC20 deposits by creating a function to move them to the hard-coded 
+4. Support ERC20 deposits by creating a function to move them to the hard-coded
 cold address. The gas cost for this should be somewhere in the 50k gas range.
-5. If the contract is killed, ERC20 should be sent to the secondary backup kill 
-address... since we can't stop ERC20 deposits, we want to leave a path for 
-fund recovery if the user deposits to an old deposit address after it's been 
+5. If the contract is killed, ERC20 should be sent to the secondary backup kill
+address... since we can't stop ERC20 deposits, we want to leave a path for
+fund recovery if the user deposits to an old deposit address after it's been
 killed.
 
 ## Structure
 
 - `ExchangeDeposit` contract is the main contract. It is deployed first.
-- `deployNewInstance(bytes32)` is called to create a new `Proxy` (one per user) that points to `ExchangeDeposit`.
-- `changeImplAddress(address)` is called to change the `address implementation` of the 
-`ExchangeDeposit` contract. Once this is non-zero, any fallback calls will be forwarded using 
+- `ProxyFactory` is the factory for generating proxies, it takes the address of the `ExchangeDeposit` instance as a constructor parameter.
+- `deployNewInstance(bytes32)` is called on `ProxyFactory` to create a new `Proxy` (one per user) that points to `ExchangeDeposit`.
+- `changeImplAddress(address)` is called on `ExchangeDeposit` to change the `address implementation` of the
+`ExchangeDeposit` contract. Once this is non-zero, any fallback calls will be forwarded using
 DELEGATECALL to allow for adding new logic to the contract afterwards.
-- `Proxy` was written in bytecode to optimize for deploy gas cost. An explanation is 
-in a large comment below the main contract code. It relays the call using CALL if msg.data 
-is null, but uses DELEGATECALL if msg.data is not-null. This way I can call `gatherErc20(address)` 
-on the proxy contract in order to gather ERC20 tokens from the `Proxy`. We can also gather other 
+- `Proxy` was written in bytecode to optimize for deploy gas cost. An explanation is
+in a large comment below the main contract code. It relays the call using CALL if msg.data
+is null, but uses DELEGATECALL if msg.data is not-null. This way we can call `gatherErc20(address)`
+on the proxy contract in order to gather ERC20 tokens from the `Proxy`. We can also gather other
 assets given to the `Proxy` after the fact by changing `address implementation`.
-- `kill()` will stop all deposits and stop DELEGATECALL to upgraded contract(s). 
+- `kill()` on `ExchangeDeposit` will stop all deposits and stop DELEGATECALL to upgraded contract(s).
 gatherErc20 and gatherEth will forward to the `address adminAddress`.
-(Since we can't refuse ERC20 payments, and a `selfdestruct` somewhere could give funds to 
+(Since we can't refuse ERC20 payments, and a `selfdestruct` somewhere could give funds to
 a deposit address, and we should be able to recover it somehow.
 
 ## Migration
 
 ```js
 const ExchangeDeposit = artifacts.require('exchangeDepositContract/ExchangeDeposit');
+const ProxyFactory = artifacts.require('exchangeDepositContract/ProxyFactory');
 
 module.exports = async (deployer, _, accounts) => {
   // COLD_ACCOUNT is the account all ETH deposits and Erc20 tokens are forwarded to.
   const COLD_ACCOUNT = accounts[0];
   // ADMIN_ACCOUNT is the account that can modify state for the main contract.
   const ADMIN_ACCOUNT = accounts[1];
+  // Deploy the main contract
   await deployer.deploy(ExchangeDeposit, COLD_ACCOUNT, ADMIN_ACCOUNT);
-
   const mainContract = await ExchangeDeposit.deployed();
-
+  // Deploy the proxy factory
+  await deployer.deploy(ProxyFactory, mainContract.address);
+  const proxyFactoryContract = await ProxyFactory.deployed();
   // 32 byte salt is needed to deploy the proxy (deposit address)
   // MUST BE GLOBALLY UNIQUE. USING THE SAME SALT TWICE WILL REVERT THE CALL.
   const salt = '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f';
   // Get the address for the proxy before we create it.
-  const proxyAccount = await mainContract.deployNewInstance.call(salt);
+  const proxyAccount = await proxyFactoryContract.deployNewInstance.call(salt);
   // Deploy the proxy
-  await mainContract.deployNewInstance(salt);
-  console.log(`* Main Logic Contract at ${mainContract.address}`);
-  console.log(`****** Proxy Contract at ${proxyAccount}`);
+  await proxyFactoryContract.deployNewInstance(salt);
+  console.log(`**** Main Logic Contract at ${mainContract.address}`);
+  console.log(`* Proxy Factory Contract at ${proxyFactoryContract.address}`);
+  console.log(`********* Proxy Contract at ${proxyAccount}`);
 };
 ```
 
@@ -76,7 +81,7 @@ $ npm run build
 
 ### deploy
 
-`exchangeDepositor` is the main logic contract and `proxy` is the 
+`exchangeDepositor` is the main logic contract and `proxy` is the
 customer deposit contract. It will take a few minutes to deploy.
 Add `ROPSTEN_GASPRICE=100000000000` to the command to set the gasPrice
 to 100 gWei etc. (Default is 80 gWei)

--- a/contracts/ProxyFactory.sol
+++ b/contracts/ProxyFactory.sol
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.11;
+
+contract ProxyFactory {
+    /// @dev See comment below for explanation of the proxy INIT_CODE
+    bytes
+        private constant INIT_CODE = hex'604080600a3d393df3fe7300000000000000000000000000000000000000003d366025573d3d3d3d34865af16031565b363d3d373d3d363d855af45b3d82803e603c573d81fd5b3d81f3';
+    /// @dev The main address that the deployed proxies will forward to.
+    address payable private immutable mainAddress;
+
+    constructor(address payable addr) public {
+        require(addr != address(0), '0x0 is an invalid address');
+        mainAddress = addr;
+    }
+
+    /**
+     * @dev This deploys an extremely minimalist proxy contract with the
+     * mainAddress embedded within.
+     * Note: The bytecode is explained in comments below this contract.
+     * @return dst The new contract address.
+     */
+    function deployNewInstance(bytes32 salt) external returns (address dst) {
+        // copy init code into memory
+        // and immutable ExchangeDeposit address onto stack
+        bytes memory initCodeMem = INIT_CODE;
+        address payable addrStack = mainAddress;
+        assembly {
+            // Get the position of the start of init code
+            let pos := add(initCodeMem, 0x20)
+            // grab the first 32 bytes
+            let first32 := mload(pos)
+            // shift the address bytes 8 bits left
+            let addrBytesShifted := shl(8, addrStack)
+            // bitwise OR them and add the address into the init code memory
+            mstore(pos, or(first32, addrBytesShifted))
+            // create the contract
+            dst := create2(
+                0, // Send no value to the contract
+                pos, // Deploy code starts at pos
+                74, // Deploy + runtime code is 74 bytes
+                salt // 32 byte salt
+            )
+            // revert if failed
+            if eq(dst, 0) {
+                revert(0, 0)
+            }
+        }
+    }
+}
+
+/*
+    // PROXY CONTRACT EXPLANATION
+
+    // DEPLOY CODE (will not be returned by web3.eth.getCode())
+    // STORE CONTRACT CODE IN MEMORY, THEN RETURN IT
+    POS | OPCODE |  OPCODE TEXT      |  STACK                               |
+    00  |  6040  |  PUSH1 0x40       |  0x40                                |
+    02  |  80    |  DUP1             |  0x40 0x40                           |
+    03  |  600a  |  PUSH1 0x0a       |  0x0a 0x40 0x40                      |
+    05  |  3d    |  RETURNDATASIZE   |  0x0 0x0a 0x40 0x40                  |
+    06  |  39    |  CODECOPY         |  0x40                                |
+    07  |  3d    |  RETURNDATASIZE   |  0x0 0x40                            |
+    08  |  f3    |  RETURN           |                                      |
+
+    09  |  fe    |  INVALID          |                                      |
+
+    // START CONTRACT CODE
+
+    // Push the ExchangeDeposit address on the stack for DUPing later
+    // Also pushing a 0x0 for DUPing later. (saves runtime AND deploy gas)
+    // Then use the calldata size as the decider for whether to jump or not
+    POS | OPCODE |  OPCODE TEXT      |  STACK                               |
+    00  |  73... |  PUSH20 ...       |  {ADDR}                              |
+    15  |  3d    |  RETURNDATASIZE   |  0x0 {ADDR}                          |
+    16  |  36    |  CALLDATASIZE     |  CDS 0x0 {ADDR}                      |
+    17  |  6025  |  PUSH1 0x25       |  0x25 CDS 0x0 {ADDR}                 |
+    19  |  57    |  JUMPI            |  0x0 {ADDR}                          |
+
+    // If msg.data length === 0, CALL into address
+    // This way, the proxy contract address becomes msg.sender and we can use
+    // msg.sender in the Deposit Event
+    // This also gives us access to our ExchangeDeposit storage (for forwarding address)
+    POS | OPCODE |  OPCODE TEXT      |  STACK                                       |
+    1A  |  3d    |  RETURNDATASIZE   |  0x0 0x0 {ADDR}                              |
+    1B  |  3d    |  RETURNDATASIZE   |  0x0 0x0 0x0 {ADDR}                          |
+    1C  |  3d    |  RETURNDATASIZE   |  0x0 0x0 0x0 0x0 {ADDR}                      |
+    1D  |  3d    |  RETURNDATASIZE   |  0x0 0x0 0x0 0x0 0x0 {ADDR}                  |
+    1E  |  34    |  CALLVALUE        |  VALUE 0x0 0x0 0x0 0x0 0x0 {ADDR}            |
+    1F  |  86    |  DUP7             |  {ADDR} VALUE 0x0 0x0 0x0 0x0 0x0 {ADDR}     |
+    20  |  5a    |  GAS              |  GAS {ADDR} VALUE 0x0 0x0 0x0 0x0 0x0 {ADDR} |
+    21  |  f1    |  CALL             |  {RES} 0x0 {ADDR}                            |
+    22  |  6031  |  PUSH1 0x31       |  0x31 {RES} 0x0 {ADDR}                       |
+    24  |  56    |  JUMP             |  {RES} 0x0 {ADDR}                            |
+
+    // If msg.data length > 0, DELEGATECALL into address
+    // This will allow us to call gatherErc20 using the context of the proxy
+    // address itself.
+    POS | OPCODE |  OPCODE TEXT      |  STACK                                 |
+    25  |  5b    |  JUMPDEST         |  0x0 {ADDR}                            |
+    26  |  36    |  CALLDATASIZE     |  CDS 0x0 {ADDR}                        |
+    27  |  3d    |  RETURNDATASIZE   |  0x0 CDS 0x0 {ADDR}                    |
+    28  |  3d    |  RETURNDATASIZE   |  0x0 0x0 CDS 0x0 {ADDR}                |
+    29  |  37    |  CALLDATACOPY     |  0x0 {ADDR}                            |
+    2A  |  3d    |  RETURNDATASIZE   |  0x0 0x0 {ADDR}                        |
+    2B  |  3d    |  RETURNDATASIZE   |  0x0 0x0 0x0 {ADDR}                    |
+    2C  |  36    |  CALLDATASIZE     |  CDS 0x0 0x0 0x0 {ADDR}                |
+    2D  |  3d    |  RETURNDATASIZE   |  0x0 CDS 0x0 0x0 0x0 {ADDR}            |
+    2E  |  85    |  DUP6             |  {ADDR} 0x0 CDS 0x0 0x0 0x0 {ADDR}     |
+    2F  |  5a    |  GAS              |  GAS {ADDR} 0x0 CDS 0x0 0x0 0x0 {ADDR} |
+    30  |  f4    |  DELEGATECALL     |  {RES} 0x0 {ADDR}                      |
+
+    // We take the result of the call, load in the returndata,
+    // If call result == 0, failure, revert
+    // else success, return
+    POS | OPCODE |  OPCODE TEXT      |  STACK                               |
+    31  |  5b    |  JUMPDEST         |  {RES} 0x0 {ADDR}                    |
+    32  |  3d    |  RETURNDATASIZE   |  RDS {RES} 0x0 {ADDR}                |
+    33  |  82    |  DUP3             |  0x0 RDS {RES} 0x0 {ADDR}            |
+    34  |  80    |  DUP1             |  0x0 0x0 RDS {RES} 0x0 {ADDR}        |
+    35  |  3e    |  RETURNDATACOPY   |  {RES} 0x0 {ADDR}                    |
+    36  |  603c  |  PUSH1 0x3c       |  0x3c {RES} 0x0 {ADDR}               |
+    38  |  57    |  JUMPI            |  0x0 {ADDR}                          |
+    39  |  3d    |  RETURNDATASIZE   |  RDS 0x0 {ADDR}                      |
+    3A  |  81    |  DUP2             |  0x0 RDS 0x0 {ADDR}                  |
+    3B  |  fd    |  REVERT           |  0x0 {ADDR}                          |
+    3C  |  5b    |  JUMPDEST         |  0x0 {ADDR}                          |
+    3D  |  3d    |  RETURNDATASIZE   |  RDS 0x0 {ADDR}                      |
+    3E  |  81    |  DUP2             |  0x0 RDS 0x0 {ADDR}                  |
+    3F  |  f3    |  RETURN           |  0x0 {ADDR}                          |
+*/

--- a/contracts/for_testing/SampleLogic.sol
+++ b/contracts/for_testing/SampleLogic.sol
@@ -22,7 +22,7 @@ contract SampleLogic {
         }
         if (
             !instance.transfer(
-                ExchangeDeposit(exchangeDepositorAddress2()).coldAddress(),
+                ExchangeDeposit(exchangeDepositorAddress()).coldAddress(),
                 forwarderBalance / 2
             )
         ) {
@@ -35,7 +35,7 @@ contract SampleLogic {
      * @dev Any address that is not a proxy will return 0x0 address.
      * @return returnAddr The address the proxy forwards to.
      */
-    function exchangeDepositorAddress2()
+    function exchangeDepositorAddress()
         public
         view
         returns (address payable returnAddr)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
   "license": "MIT",
   "files": [
     "contracts/ExchangeDeposit.sol",
-    "build/contracts/ExchangeDeposit.json"
+    "build/contracts/ExchangeDeposit.json",
+    "contracts/ProxyFactory.sol",
+    "build/contracts/ProxyFactory.json"
   ],
   "devDependencies": {
     "@truffle/hdwallet-provider": "^1.0.40",


### PR DESCRIPTION
Alternative to #6 

This removes the bytecode logic from ExchangeDeposit and creates a new ProxyFactory contract from which we deploy proxy contracts. (It takes the address of the ExchangeDeposit contract as a constructor parameter)